### PR TITLE
ci: renovate extends bcgov/renovate-config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,14 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "packageRules": [
-    {
-      "matchUpdateTypes": [
-        "minor",
-        "patch",
-        "pin",
-        "digest"
-      ],
-      "automerge": true
-    }
+  "description": "Presets from https://github.com/bcgov/renovate-config",
+  "extends": [
+    "github>bcgov/renovate-config"
   ]
 }


### PR DESCRIPTION
Upstream config.  Should prevent major updates to contaienrs, which breaks our pattern.

---

Thanks for the PR!

Any new images should be viewable with [our repo packages](https://github.com/orgs/bcgov/packages?repo_name=nr-containers).  :)