### PR TITLE
Replace postgres 15.5

### DIFF
--- a/postgres/15/Dockerfile
+++ b/postgres/15/Dockerfile
@@ -1,5 +1,5 @@
 FROM postgres:15.5
 
 # Health check and non-privileged user
-HEALTHCHECK --interval=15s --timeout=5s --retries=3 CMD [ "pg_isready" ]
+HEALTHCHECK CMD [ "pg_isready" ]
 USER postgres


### PR DESCRIPTION
This package is kicking up manifest unknow errors.  Replace it.

```
database: docker pull ghcr.io/bcgov/nr-containers/postgres:15.5
15.5: Pulling from bcgov/nr-containers/postgres
manifest unknown
```

---

Thanks for the PR!

Any new images should be viewable with [our repo packages](https://github.com/orgs/bcgov/packages?repo_name=nr-containers).  :)